### PR TITLE
Use correct registry ID for goldtoken

### DIFF
--- a/celotokens/celotokens.go
+++ b/celotokens/celotokens.go
@@ -31,7 +31,7 @@ type CeloTokenInfo struct {
 
 // CELOInfo contains info on the CELO token
 var CELOInfo = CeloTokenInfo{
-	registryID:    registry.StableTokenContractID,
+	registryID:    registry.GoldTokenContractID,
 	isStableToken: false,
 }
 


### PR DESCRIPTION
Looks like I accidentally set CELO's registry ID as StableToken when refactoring things. Oops!