### PR TITLE
Add GetExchangeRegistryID for stable tokens

### DIFF
--- a/celotokens/celotokens.go
+++ b/celotokens/celotokens.go
@@ -206,14 +206,14 @@ func GetRegistryID(token CeloToken) (registry.ContractID, error) {
 	return tokenInfo.registryID, nil
 }
 
-// GetRegistryID gets the contract's registry ID for a given token
+// GetExchangeRegistryID gets the exchange contract's registry ID for a given token
 func GetExchangeRegistryID(token CeloToken) (registry.ContractID, error) {
 	tokenInfo, ok := CeloTokenInfos[token]
 	if !ok {
-		return nil, fmt.Errorf("Token %w not found", token)
+		return "", fmt.Errorf("Token %w not found", token)
 	}
 	if !tokenInfo.isStableToken {
-		return nil, fmt.Errorf("Token %w not a stable token", token)
+		return "", fmt.Errorf("Token %w not a stable token", token)
 	}
 	return tokenInfo.exchangeRegistryID, nil
 }

--- a/celotokens/celotokens.go
+++ b/celotokens/celotokens.go
@@ -206,7 +206,7 @@ func GetRegistryID(token CeloToken) (registry.ContractID, error) {
 	return tokenInfo.registryID, nil
 }
 
-// GetExchangeRegistryID gets the exchange contract's registry ID for a given token
+// GetExchangeRegistryID gets the exchange contract's registry ID for a given stable token
 func GetExchangeRegistryID(token CeloToken) (registry.ContractID, error) {
 	tokenInfo, ok := CeloTokenInfos[token]
 	if !ok {

--- a/celotokens/celotokens.go
+++ b/celotokens/celotokens.go
@@ -205,3 +205,15 @@ func GetRegistryID(token CeloToken) (registry.ContractID, error) {
 	}
 	return tokenInfo.registryID, nil
 }
+
+// GetRegistryID gets the contract's registry ID for a given token
+func GetExchangeRegistryID(token CeloToken) (registry.ContractID, error) {
+	tokenInfo, ok := CeloTokenInfos[token]
+	if !ok {
+		return nil, fmt.Errorf("Token %w not found", token)
+	}
+	if !tokenInfo.isStableToken {
+		return nil, fmt.Errorf("Token %w not a stable token", token)
+	}
+	return tokenInfo.exchangeRegistryID, nil
+}


### PR DESCRIPTION
* Adds `GetExchangeRegistryID` to easily get the registry ID of a given stable token's exchange contract

Needed for some changes to eksportisto