### PR TITLE
Fix transfer tracing error handling

### DIFF
--- a/client/debug/tracer.go
+++ b/client/debug/tracer.go
@@ -37,6 +37,8 @@ var transferTracer = `
   callStack: [ { transfers: [] } ],
   statusRevert: 'revert',
   statusSuccess: 'success',
+  testOpOut: '',
+  testOpLen: '',
 
   topCall() {
     return this.callStack[this.callStack.length - 1];
@@ -193,10 +195,12 @@ var transferTracer = `
     this.assertStackHeightEquals(1, true, "");
     const rootCall = this.topCall();
 
-    // Execution of root call failed and returned no bytes as output
-    if (!ctx.output.length) {
-      rootCall.reverted = true
-    }
+    // // Execution of root call failed and returned no bytes as output
+    // if (!ctx.output.length) {
+    //   // rootCall.reverted = true;
+    // }
+    // this.testOpOut = ctx.type;
+    // this.testOpLen = ctx.output.length;
 
     const transfers = []
     this.pushTransfers(transfers, rootCall.transfers,
@@ -227,12 +231,16 @@ var transferTracer = `
       block:     ctx.block,
       time:      ctx.time,
       transfers: transfers,
+      // testOpOut: this.testOpOut,
+      // testOpLen: this.testOpLen,
     };
   },
 }`
 
 type transferTracerResponse struct {
 	Transfers []Transfer `json:"transfers"`
+  // TestOpOut string `json:"testOpOut"`
+  // TestOpLen int `json:"testOpLen"`
 }
 
 type TransferStatus string
@@ -285,6 +293,8 @@ func (dc *DebugClient) TransactionTransfers(ctx context.Context, txhash common.H
 	err := dc.TraceTransaction(ctx, &response, txhash, tracerConfig)
 	if err != nil {
 		return nil, err
-	}	
+	}
+  // fmt.Printf("TestOpOut: %s\n", response.TestOpOut)
+  // fmt.Printf("TestOpLen: %d\n", response.TestOpLen)
 	return response.Transfers, nil
 }

--- a/client/debug/tracer.go
+++ b/client/debug/tracer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/celo-org/celo-blockchain/common"
@@ -75,14 +76,19 @@ var transferTracer = `
 
     if (this.callStack.length > depth) {
       const finishedCall = this.callStack.pop();
+      const ret = log.stack.peek(0);
+
+      // Execution of opcode failed and returned 0
+      if (ret.equals(0)) {
+        finishedCall.reverted = true;
+      }
 
       // Find to address for nested contract create with value.
       if ((finishedCall.op == 'CREATE' || finishedCall.op == 'CREATE2') &&
           finishedCall.transfers.length > 0 && !finishedCall.transfers[0].to) {
         const createTransfer = finishedCall.transfers[0];
-        const ret = log.stack.peek(0);
         createTransfer.to = toHex(toAddress(ret.toString(16)));
-        createTransfer.status = ret.equals(0) ? this.statusRevert : this.statusSuccess;
+        createTransfer.status = finishedCall.reverted ? this.statusRevert : this.statusSuccess;
       }
 
       // Propagate transfers made during the successful call.
@@ -187,6 +193,12 @@ var transferTracer = `
   result(ctx, db) {
     this.assertStackHeightEquals(1, true, "");
     const rootCall = this.topCall();
+
+    // Execution of root call failed and returned no bytes as output
+    if (!ctx.output.length) {
+      rootCall.reverted = true
+    }
+
     const transfers = []
     this.pushTransfers(transfers, rootCall.transfers,
                        rootCall.reverted ? this.statusRevert : this.statusSuccess);
@@ -220,8 +232,119 @@ var transferTracer = `
   },
 }`
 
+var transferTracerDebug = `
+{
+  addrSender: toAddress("0xedb01dd335611ee1e86033d973442409ac34b0da"),
+  addrContract: toAddress("0x2036cacd81b658c3237928b8afff68ca7d570d16"),
+  addrReceiver: toAddress("0xf36a5c550a943741e1da707c3c81010baad01abc"),
+
+  balanceSender: undefined,
+  balanceContract: undefined,
+  balanceReceiver: undefined,
+  balancesSender: [],
+  balancesContract: [],
+  balancesReceiver: [],
+  balanceSenderChanges: 0,
+  balanceContractChanges: 0,
+  balanceReceiverChanges: 0,
+  wasAFault: false,
+  prevOpWhereChangeHappened: "",
+  opWhereChangeHappened: "",
+  prevOp: "",
+
+  fault(log, db) {
+    this.wasAFault = true
+  },
+
+  // step() is invoked for every opcode that the VM executes.
+  step(log, db) {
+    const error = log.getError();
+    if (error !== undefined) {
+      this.fault(log, db);
+    }
+
+    // TODO check if there's a change here
+    const currBalSender = db.getBalance(this.addrSender).toString();
+    const currBalContract = db.getBalance(this.addrContract).toString();
+    const currBalReceiver = db.getBalance(this.addrReceiver).toString();
+
+    if (this.balanceSender !== undefined) {
+      if (currBalSender != this.balanceSender) {
+        this.balanceSenderChanges += 1;
+        this.opWhereChangeHappened = log.op.toString();
+        this.prevOpWhereChangeHappened = this.prevOp;
+      }
+    }
+    if (this.balanceContract !== undefined) {
+      if (currBalContract != this.balanceContract) {
+        this.balanceContractChanges += 1;
+      }
+    }
+    if (this.balanceReceiver !== undefined) {
+      if (currBalReceiver != this.balanceReceiver) {
+        this.balanceReceiverChanges += 1;
+      }
+    }
+    this.balanceSender = currBalSender;
+    this.balancesSender.push(currBalSender);
+    this.balanceContract = currBalContract;
+    this.balancesContract.push(currBalContract);
+    this.balanceReceiver = currBalReceiver;
+    this.balancesReceiver.push(currBalReceiver);
+    this.prevOp = log.op.toString();
+  },
+
+  result(ctx, db) {
+
+    // TODO return all the fields that we want to see out of this, create a Go type to add these fields in
+    return {
+      type:      ctx.type,
+      from:      toHex(ctx.from),
+      to:        toHex(ctx.to),
+      value:     '0x' + ctx.value.toString(16),
+      gas:       '0x' + bigInt(ctx.gas).toString(16),
+      gasUsed:   '0x' + bigInt(ctx.gasUsed).toString(16),
+      block:     ctx.block,
+      time:      ctx.time,
+      endBalanceSender: this.balanceSender,
+      endBalanceContract: this.balanceContract,
+      endBalanceReceiver: this.balanceReceiver,
+      balanceSenderChanges: this.balanceSenderChanges,
+      balanceContractChanges: this.balanceContractChanges,
+      balanceReceiverChanges: this.balanceReceiverChanges,
+      wasAFault: this.wasAFault,
+      balancesSender: this.balancesSender,
+      balancesContract: this.balancesContract,
+      balancesReceiver: this.balancesReceiver,
+      prevOpWhereChangeHappened: this.prevOpWhereChangeHappened,
+      opWhereChangeHappened: this.opWhereChangeHappened,
+      prevOp: this.prevOp,
+    
+    };
+  },
+}
+`
+
 type transferTracerResponse struct {
 	Transfers []Transfer `json:"transfers"`
+}
+
+type transferTracerDebugResponse struct {
+  Gas string `json:"gas"`
+  GasUsed string `json:"gasUsed"`
+  EndBalanceSender string `json:"endBalanceSender"`
+  EndBalanceContract string `json:"endBalanceContract"`
+  EndBalanceReceiver string `json:"endBalanceReceiver"`
+  BalanceSenderChanges int `json:"balanceSenderChanges"`
+  BalanceContractChanges int `json:"balanceContractChanges"`
+  BalanceReceiverChanges int `json:"balanceReceiverChanges"`
+  WasAFault bool `json:"wasAFault"`
+  BalancesSender []string `json:"balancesSender"`
+  BalancesContract[] string `json:"balancesContract"`
+  BalancesReceiver[] string `json:"balancesReceiver"`
+  PrevOpWhereChangeHappened string `json:"prevOpWhereChangeHappened"`
+  OpWhereChangeHappened string `json:"opWhereChangeHappened"`
+  PrevOp string `json:"prevOp"`
 }
 
 type TransferStatus string
@@ -238,6 +361,7 @@ type Transfer struct {
 	To     common.Address `json:"to"`
 	Value  *big.Int       `json:"value"`
 	Status TransferStatus `json:"status"`
+  Type   string         `json:"type"`
 }
 
 // UnmarshalJSON unmarshals from JSON.
@@ -247,6 +371,7 @@ func (t *Transfer) UnmarshalJSON(input []byte) error {
 		To     common.Address `json:"to"`
 		Value  *hexutil.Big   `json:"value"`
 		Status TransferStatus `json:"status"`
+    Type   string         `json:"type"`
 	}
 	var dec Transfer
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -257,6 +382,8 @@ func (t *Transfer) UnmarshalJSON(input []byte) error {
 	t.To = dec.To
 	t.Value = (*big.Int)(dec.Value)
 	t.Status = dec.Status
+  t.Type = dec.Type
+
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' for Transfer")
 	}
@@ -267,9 +394,49 @@ func (dc *DebugClient) TransactionTransfers(ctx context.Context, txhash common.H
 	tracerConfig := &eth.TraceConfig{Timeout: &transferTracerTimeout, Tracer: &transferTracer}
 	var response transferTracerResponse
 
+  fmt.Println("Within kliento TransactionTransfers")
 	err := dc.TraceTransaction(ctx, &response, txhash, tracerConfig)
 	if err != nil {
 		return nil, err
 	}
+  for _, transfer := range response.Transfers {
+    fmt.Printf("Value: %d\n", transfer.Value)
+    fmt.Printf("From: %x\n", transfer.From)
+    fmt.Printf("To: %x\n", transfer.To)
+    fmt.Printf("Status: %s\n", transfer.Status)
+    fmt.Printf("Type: %s\n", transfer.Type)
+  }
+
+  // DEBUG
+  tracerConfigDebug := &eth.TraceConfig{Timeout: &transferTracerTimeout, Tracer: &transferTracerDebug}
+	var debugResponse transferTracerDebugResponse
+
+  fmt.Println("Within kliento TransactionTransfers")
+	errDebug := dc.TraceTransaction(ctx, &debugResponse, txhash, tracerConfigDebug)
+	if errDebug != nil {
+		return nil, errDebug
+	}
+
+  // fmt.Printf("EndBalanceSender: %s\n", debugResponse.EndBalanceSender)
+  // fmt.Printf("EndBalanceContract: %s\n", debugResponse.EndBalanceContract)
+  // fmt.Printf("EndBalanceReceiver: %s\n", debugResponse.EndBalanceReceiver)
+  // fmt.Printf("BalanceSenderChanges: %d\n", debugResponse.BalanceSenderChanges)
+  // fmt.Printf("BalanceContractChanges: %d\n", debugResponse.BalanceContractChanges)
+  // fmt.Printf("BalanceReceiverChanges: %d\n", debugResponse.BalanceReceiverChanges)
+  // fmt.Printf("WasAFault: %t\n", debugResponse.WasAFault)
+  // fmt.Printf("PrevOpWhereChangeHappened: %s\n", debugResponse.PrevOpWhereChangeHappened)
+  // fmt.Printf("OpWhereChangeHappened: %s\n", debugResponse.OpWhereChangeHappened)
+  // fmt.Printf("PrevOp: %s\n", debugResponse.PrevOp)
+  
+  // // fmt.Printf("BalancesSender: %v\n", debugResponse.BalancesSender)
+  // // fmt.Printf("BalancesContract: %v\n", debugResponse.BalancesContract)
+  // // fmt.Printf("BalancesReceiver: %v\n", debugResponse.BalancesReceiver)
+
+  // fmt.Printf("Gas: %s\n", debugResponse.Gas)
+  // fmt.Printf("GasUsed: %s\n", debugResponse.GasUsed)
+
+
+  // END DEBUG
+	
 	return response.Transfers, nil
 }

--- a/client/debug/tracer.go
+++ b/client/debug/tracer.go
@@ -243,7 +243,6 @@ type Transfer struct {
 	To     common.Address `json:"to"`
 	Value  *big.Int       `json:"value"`
 	Status TransferStatus `json:"status"`
-	Type   string         `json:"type"`
 }
 
 // UnmarshalJSON unmarshals from JSON.
@@ -253,7 +252,6 @@ func (t *Transfer) UnmarshalJSON(input []byte) error {
 		To     common.Address `json:"to"`
 		Value  *hexutil.Big   `json:"value"`
 		Status TransferStatus `json:"status"`
-		Type   string         `json:"type"`
 	}
 	var dec Transfer
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -264,8 +262,6 @@ func (t *Transfer) UnmarshalJSON(input []byte) error {
 	t.To = dec.To
 	t.Value = (*big.Int)(dec.Value)
 	t.Status = dec.Status
-	t.Type = dec.Type
-
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' for Transfer")
 	}

--- a/client/debug/tracer.go
+++ b/client/debug/tracer.go
@@ -37,8 +37,6 @@ var transferTracer = `
   callStack: [ { transfers: [] } ],
   statusRevert: 'revert',
   statusSuccess: 'success',
-  testOpOut: '',
-  testOpLen: '',
 
   topCall() {
     return this.callStack[this.callStack.length - 1];
@@ -194,14 +192,6 @@ var transferTracer = `
   result(ctx, db) {
     this.assertStackHeightEquals(1, true, "");
     const rootCall = this.topCall();
-
-    // // Execution of root call failed and returned no bytes as output
-    // if (!ctx.output.length) {
-    //   // rootCall.reverted = true;
-    // }
-    // this.testOpOut = ctx.type;
-    // this.testOpLen = ctx.output.length;
-
     const transfers = []
     this.pushTransfers(transfers, rootCall.transfers,
                        rootCall.reverted ? this.statusRevert : this.statusSuccess);
@@ -231,16 +221,12 @@ var transferTracer = `
       block:     ctx.block,
       time:      ctx.time,
       transfers: transfers,
-      // testOpOut: this.testOpOut,
-      // testOpLen: this.testOpLen,
     };
   },
 }`
 
 type transferTracerResponse struct {
 	Transfers []Transfer `json:"transfers"`
-  // TestOpOut string `json:"testOpOut"`
-  // TestOpLen int `json:"testOpLen"`
 }
 
 type TransferStatus string
@@ -257,7 +243,7 @@ type Transfer struct {
 	To     common.Address `json:"to"`
 	Value  *big.Int       `json:"value"`
 	Status TransferStatus `json:"status"`
-  Type   string         `json:"type"`
+	Type   string         `json:"type"`
 }
 
 // UnmarshalJSON unmarshals from JSON.
@@ -267,7 +253,7 @@ func (t *Transfer) UnmarshalJSON(input []byte) error {
 		To     common.Address `json:"to"`
 		Value  *hexutil.Big   `json:"value"`
 		Status TransferStatus `json:"status"`
-    Type   string         `json:"type"`
+		Type   string         `json:"type"`
 	}
 	var dec Transfer
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -278,7 +264,7 @@ func (t *Transfer) UnmarshalJSON(input []byte) error {
 	t.To = dec.To
 	t.Value = (*big.Int)(dec.Value)
 	t.Status = dec.Status
-  t.Type = dec.Type
+	t.Type = dec.Type
 
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' for Transfer")
@@ -294,7 +280,5 @@ func (dc *DebugClient) TransactionTransfers(ctx context.Context, txhash common.H
 	if err != nil {
 		return nil, err
 	}
-  // fmt.Printf("TestOpOut: %s\n", response.TestOpOut)
-  // fmt.Printf("TestOpLen: %d\n", response.TestOpLen)
 	return response.Transfers, nil
 }


### PR DESCRIPTION
# Description
Adds check for returned value (on stack) -- if execution of opcode failed and returned 0, we now revert this call. Previously, we hadn't done this, meaning that we caught opcodes that failed and `REVERT`ed, but not calls that failed without throwing a `REVERT` afterwards.

Note: did not add additional handling to `result` --> 1. the output of this does not seem to be the same as the return value (consistently); a null `ctx.output` does not mean that the transaction failed in the rootCall. Also, I think that if the overall root call fails, this should be handled in the last `RETURN` or `STOP` stepped through. @mcortesi -- does that sound reasonable to you? 

# testing
- manual testing
- currently running full CLI checks on rosetta with this (which will reconcile all transfers from tracing against account balances from `eth_getBalance`) -- will switch this to non-draft as soon as this these checks are through. --> alfajores looks good, mainnet looks good with about 88% of the chain scanned + reconciled
