### PR TITLE
Fix Unexpected stack height tracer error

### DIFF
--- a/client/debug/tracer.go
+++ b/client/debug/tracer.go
@@ -189,8 +189,11 @@ var transferTracer = `
 
   // result() is invoked when all the opcodes have been iterated over and returns
   // the final result of the tracing.
+  //
+  // Note that no errors should be thrown from this function because they will
+  // override any other errors thrown from this script and timeout errors
+  // managed by geth.
   result(ctx, db) {
-    this.assertStackHeightEquals(1, true, "");
     const rootCall = this.topCall();
     const transfers = []
     this.pushTransfers(transfers, rootCall.transfers,


### PR DESCRIPTION
We previously were checking the stack height in the result func and
erroring if it was not what we expected it to be. The problem with this
approach was that the result function is always called when tracing
finishes and any error thrown in result overrides any previously thrown
error and timeout errors managed by geth. As such when timeouts occurred
the stack was often not at the expected height and instead of seeing a
timeout error you would instead see an error about an unexpected stack
height.

Fixes https://github.com/celo-org/eksportisto/issues/96 https://github.com/celo-org/eksportisto/issues/107 https://github.com/celo-org/rosetta/issues/180
These issues were most likely a result of  a low timeout, which can now be raised.
